### PR TITLE
error if Android `local.properties` is committed into the repo - completed

### DIFF
--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -108,19 +108,21 @@ func (scanner *Scanner) ExcludedScannerNames() []string {
 
 // Options ...
 func (scanner *Scanner) Options() (models.OptionModel, models.Warnings, error) {
+	warnings := models.Warnings{}
 
 	// Search for local.properties file
 	for _, filePath := range scanner.FileList {
 		if strings.Contains(filePath, "local.properties") {
-			log.Warnft(`the local.properties file should not be committed into the repository. The location of the file is:
+			warningText := fmt.Sprintf(`the local.properties file should not be committed into the repository. The location of the file is:
 %s`, filePath)
+			log.Warnft(warningText)
+			warnings = append(warnings, fmt.Sprintf(warningText))
 		}
 	}
 
 	// Search for gradle wrapper
 	log.Infoft("Searching for gradlew files")
 
-	warnings := models.Warnings{}
 	gradlewFiles, err := utility.FilterGradlewFiles(scanner.FileList)
 	if err != nil {
 		return models.OptionModel{}, warnings, fmt.Errorf("Failed to list gradlew files, error: %s", err)

--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -2,6 +2,7 @@ package android
 
 import (
 	"fmt"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 
@@ -75,6 +76,13 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
 		return false, fmt.Errorf("failed to search for files in (%s), error: %s", searchDir, err)
 	}
 	scanner.FileList = fileList
+
+	// Search for local.properties file
+	for _, fileName := range fileList {
+		if strings.Contains(fileName, "local.properties") {
+			return false, fmt.Errorf("the local.properties file should not be committed into the repository")
+		}
+	}
 
 	// Search for gradle file
 	log.Infoft("Searching for build.gradle files")

--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -78,9 +78,10 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
 	scanner.FileList = fileList
 
 	// Search for local.properties file
-	for _, fileName := range fileList {
-		if strings.Contains(fileName, "local.properties") {
-			return false, fmt.Errorf("the local.properties file should not be committed into the repository")
+	for _, filePath := range fileList {
+		if strings.Contains(filePath, "local.properties") {
+			return false, fmt.Errorf(`the local.properties file should not be committed into the repository. The location of the file is:
+%s`, filePath)
 		}
 	}
 

--- a/scanners/android/android.go
+++ b/scanners/android/android.go
@@ -77,14 +77,6 @@ func (scanner *Scanner) DetectPlatform(searchDir string) (bool, error) {
 	}
 	scanner.FileList = fileList
 
-	// Search for local.properties file
-	for _, filePath := range fileList {
-		if strings.Contains(filePath, "local.properties") {
-			return false, fmt.Errorf(`the local.properties file should not be committed into the repository. The location of the file is:
-%s`, filePath)
-		}
-	}
-
 	// Search for gradle file
 	log.Infoft("Searching for build.gradle files")
 
@@ -116,6 +108,15 @@ func (scanner *Scanner) ExcludedScannerNames() []string {
 
 // Options ...
 func (scanner *Scanner) Options() (models.OptionModel, models.Warnings, error) {
+
+	// Search for local.properties file
+	for _, filePath := range scanner.FileList {
+		if strings.Contains(filePath, "local.properties") {
+			log.Warnft(`the local.properties file should not be committed into the repository. The location of the file is:
+%s`, filePath)
+		}
+	}
+
 	// Search for gradle wrapper
 	log.Infoft("Searching for gradlew files")
 


### PR DESCRIPTION
Scanner (or somewhere else? e.g. in Gradle Runner?): warning if Android `local.properties` is committed into the repo

If the local.properties file is committed into the repo you'll get an error for any Android/Gradle build like:

```
* What went wrong:
A problem occurred configuring project ':app'.
> The SDK directory '/Users/rodrigosimoesrosa/Library/Android/sdk' does not exist.
```

Note the directory path -> it's the path __on the user's Mac!__