### PR TITLE
Run apt-get update before installing system dependencies

### DIFF
--- a/_tests/integration/ruby_test.go
+++ b/_tests/integration/ruby_test.go
@@ -364,6 +364,7 @@ configs:
                   #!/usr/bin/env bash
                   set -euxo pipefail
 
+                  apt-get update
                   apt-get install -y libmariadb-dev
           - script@%s:
               title: Install dependencies

--- a/scanners/ruby/config.go
+++ b/scanners/ruby/config.go
@@ -229,7 +229,7 @@ func collectAptPackages(databases []databaseGem) []string {
 }
 
 func generateSystemDepsScript(packages []string) string {
-	return "#!/usr/bin/env bash\nset -euxo pipefail\n\napt-get install -y " + strings.Join(packages, " ") + "\n"
+	return "#!/usr/bin/env bash\nset -euxo pipefail\n\napt-get update\napt-get install -y " + strings.Join(packages, " ") + "\n"
 }
 
 func serviceContainerReferences(databases []databaseGem) []stepmanModels.ContainerReference {


### PR DESCRIPTION
### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

Fix: Run apt-get update before installing system dependencies

The generated "Install system dependencies" script was calling `apt-get install` without first running `apt-get update`, causing package installation to fail on CI runners with a stale or empty package index:

```
E: Unable to locate package libmariadb-dev
```

Added `apt-get update` before the install command in `generateSystemDepsScript`.
