### PR TITLE
Python scanner

### DIFF
--- a/_manual-config/go.mod
+++ b/_manual-config/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/bitrise-io/bitrise/v2 v2.39.1 // indirect
 	github.com/bitrise-io/envman/v2 v2.5.6 // indirect
-	github.com/bitrise-io/go-flutter v0.1.2-0.20260413123617-d1289effff65 // indirect
+	github.com/bitrise-io/go-flutter v0.3.0 // indirect
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.33 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/_manual-config/go.sum
+++ b/_manual-config/go.sum
@@ -11,6 +11,9 @@ github.com/bitrise-io/envman/v2 v2.5.6/go.mod h1:JJjnW87+zJj0Ft4QxuouiIJ40Ir8ZYQ
 github.com/bitrise-io/go-flutter v0.1.1 h1:EKgwqiyeuyMf9V0Oad/MbMNrDA4wh2OZfIWZw5UF/Hs=
 github.com/bitrise-io/go-flutter v0.1.1/go.mod h1:FJyNN3BaI4ifHNaDO8bfkBgFroeybXUczEpOYuBlENo=
 github.com/bitrise-io/go-flutter v0.1.2-0.20260413123617-d1289effff65/go.mod h1:FJyNN3BaI4ifHNaDO8bfkBgFroeybXUczEpOYuBlENo=
+github.com/bitrise-io/go-flutter v0.2.1-0.20260428141131-b93699c0adfe/go.mod h1:FJyNN3BaI4ifHNaDO8bfkBgFroeybXUczEpOYuBlENo=
+github.com/bitrise-io/go-flutter v0.3.0 h1:7uOFifbYW0s/RNvPcA8OunGQFB+e3nls1XBdxxC6jww=
+github.com/bitrise-io/go-flutter v0.3.0/go.mod h1:FJyNN3BaI4ifHNaDO8bfkBgFroeybXUczEpOYuBlENo=
 github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10 h1:/2OyBFI7GjYKexBPcfTPvKFz8Ks7qYzkkz2SQ8aiJgc=
 github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10/go.mod h1:pARutiL3kEuRLV3JvswidvfCj+9Y3qMZtji2BDqLFsA=
 github.com/bitrise-io/go-steputils v1.0.6 h1:eBRL70DWwEd7DWYGd5Ds7OSIY5HElzhoDOI6UuITKQg=

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -318,6 +318,29 @@ var customConfigVersions = []interface{}{
 	steps.GitCloneVersion,
 	steps.DeployToBitriseIoVersion,
 
+	// python
+	// default-python-pip-config
+	models.FormatVersion,
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.ScriptVersion,
+	steps.CacheRestoreVersion,
+	steps.ScriptVersion,
+	steps.ScriptVersion,
+	steps.CacheSaveVersion,
+	steps.DeployToBitriseIoVersion,
+
+	// default-python-poetry-config
+	models.FormatVersion,
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.ScriptVersion,
+	steps.CacheRestoreVersion,
+	steps.ScriptVersion,
+	steps.ScriptVersion,
+	steps.CacheSaveVersion,
+	steps.DeployToBitriseIoVersion,
+
 	// react native
 	// default-react-native-config/deploy
 	models.FormatVersion,
@@ -694,6 +717,29 @@ var customConfigResultYML = fmt.Sprintf(`options:
                 config: default-node-js-npm-config
               yarn:
                 config: default-node-js-yarn-config
+  python:
+    title: Python Project Directory
+    summary: The directory containing the Python project files (requirements.txt,
+      pyproject.toml, etc.)
+    env_key: PYTHON_PROJECT_DIR
+    type: user_input
+    value_map:
+      "":
+        title: Python version
+        summary: The Python version to be used for the project. Use exact (3.12.0)
+          or partial (3.12:latest, 3:installed) versions.
+        env_key: PYTHON_VERSION
+        type: user_input
+        value_map:
+          "":
+            title: Package Manager
+            summary: The package manager used in the project
+            type: selector
+            value_map:
+              pip:
+                config: default-python-pip-config
+              poetry:
+                config: default-python-poetry-config
   react-native:
     title: Is this an [Expo](https://expo.dev)-based React Native project?
     summary: |-
@@ -1523,6 +1569,95 @@ configs:
           - activate-ssh-key@%s:
               run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
           - git-clone@%s: {}
+          - deploy-to-bitrise-io@%s: {}
+  python:
+    default-python-pip-config: |
+      format_version: "%s"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: python
+      workflows:
+        run_tests:
+          steps:
+          - activate-ssh-key@%s:
+              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - git-clone@%s: {}
+          - script@%s:
+              title: Install Python
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  bitrise tools install python $PYTHON_VERSION
+          - restore-cache@%s:
+              inputs:
+              - key: pip-{{ checksum "requirements.txt" }}
+          - script@%s:
+              title: Install dependencies
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  pip install -r requirements.txt
+              - working_dir: $PYTHON_PROJECT_DIR
+          - script@%s:
+              title: Run tests
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  pytest
+              - working_dir: $PYTHON_PROJECT_DIR
+          - save-cache@%s:
+              inputs:
+              - key: pip-{{ checksum "requirements.txt" }}
+              - paths: ~/.cache/pip
+          - deploy-to-bitrise-io@%s: {}
+    default-python-poetry-config: |
+      format_version: "%s"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: python
+      workflows:
+        run_tests:
+          steps:
+          - activate-ssh-key@%s:
+              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - git-clone@%s: {}
+          - script@%s:
+              title: Install Python
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  bitrise tools install python $PYTHON_VERSION
+          - restore-cache@%s:
+              inputs:
+              - key: poetry-{{ checksum "poetry.lock" }}
+          - script@%s:
+              title: Install dependencies
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  poetry install
+              - working_dir: $PYTHON_PROJECT_DIR
+          - script@%s:
+              title: Run tests
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  poetry run pytest
+              - working_dir: $PYTHON_PROJECT_DIR
+          - save-cache@%s:
+              inputs:
+              - key: poetry-{{ checksum "poetry.lock" }}
+              - paths: ~/.cache/pypoetry
           - deploy-to-bitrise-io@%s: {}
   react-native:
     default-react-native-config: |

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -341,6 +341,17 @@ var customConfigVersions = []interface{}{
 	steps.CacheSaveVersion,
 	steps.DeployToBitriseIoVersion,
 
+	// default-python-uv-config
+	models.FormatVersion,
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.ScriptVersion,
+	steps.CacheRestoreVersion,
+	steps.ScriptVersion,
+	steps.ScriptVersion,
+	steps.CacheSaveVersion,
+	steps.DeployToBitriseIoVersion,
+
 	// react native
 	// default-react-native-config/deploy
 	models.FormatVersion,
@@ -740,6 +751,8 @@ var customConfigResultYML = fmt.Sprintf(`options:
                 config: default-python-pip-config
               poetry:
                 config: default-python-poetry-config
+              uv:
+                config: default-python-uv-config
   react-native:
     title: Is this an [Expo](https://expo.dev)-based React Native project?
     summary: |-
@@ -1658,6 +1671,50 @@ configs:
               inputs:
               - key: poetry-{{ checksum "poetry.lock" }}
               - paths: ~/.cache/pypoetry
+          - deploy-to-bitrise-io@%s: {}
+    default-python-uv-config: |
+      format_version: "%s"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: python
+      workflows:
+        run_tests:
+          steps:
+          - activate-ssh-key@%s:
+              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - git-clone@%s: {}
+          - script@%s:
+              title: Install Python
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  bitrise tools install python $PYTHON_VERSION
+          - restore-cache@%s:
+              inputs:
+              - key: uv-{{ checksum "uv.lock" }}
+          - script@%s:
+              title: Install dependencies
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  uv sync
+              - working_dir: $PYTHON_PROJECT_DIR
+          - script@%s:
+              title: Run tests
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  uv run pytest
+              - working_dir: $PYTHON_PROJECT_DIR
+          - save-cache@%s:
+              inputs:
+              - key: uv-{{ checksum "uv.lock" }}
+              - paths: ~/.cache/uv
           - deploy-to-bitrise-io@%s: {}
   react-native:
     default-react-native-config: |

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -1656,6 +1656,7 @@ configs:
                   #!/usr/bin/env bash
                   set -euxo pipefail
 
+                  pip install poetry
                   poetry install
               - working_dir: $PYTHON_PROJECT_DIR
           - script@%s:
@@ -1700,6 +1701,7 @@ configs:
                   #!/usr/bin/env bash
                   set -euxo pipefail
 
+                  pip install uv
                   uv sync
               - working_dir: $PYTHON_PROJECT_DIR
           - script@%s:

--- a/_tests/integration/manual_config_test.go
+++ b/_tests/integration/manual_config_test.go
@@ -1612,6 +1612,7 @@ configs:
                   #!/usr/bin/env bash
                   set -euxo pipefail
 
+                  pip install --upgrade pip
                   pip install -r requirements.txt
               - working_dir: $PYTHON_PROJECT_DIR
           - script@%s:
@@ -1657,7 +1658,7 @@ configs:
                   set -euxo pipefail
 
                   pip install poetry
-                  poetry install
+                  poetry install --no-root
               - working_dir: $PYTHON_PROJECT_DIR
           - script@%s:
               title: Run tests

--- a/_tests/integration/python_test.go
+++ b/_tests/integration/python_test.go
@@ -51,8 +51,6 @@ configs:
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: python
-      meta:
-        bitrise.io/framework: fastapi
       workflows:
         run_tests:
           steps:

--- a/_tests/integration/python_test.go
+++ b/_tests/integration/python_test.go
@@ -1,0 +1,91 @@
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bitrise-io/bitrise-init/_tests/integration/helper"
+	"github.com/bitrise-io/bitrise-init/models"
+	"github.com/bitrise-io/bitrise-init/steps"
+)
+
+func TestPython(t *testing.T) {
+	var testCases = []helper.TestCase{
+		{
+			Name:              "fastapi-sample",
+			RepoURL:           "https://github.com/bitrise-io/python-samples.git",
+			RelativeSearchDir: "fastapi-sample",
+			Branch:            "main",
+			ExpectedResult:    pythonFastapiResultYML,
+			ExpectedVersions:  pythonFastapiResultVersions,
+		},
+	}
+
+	helper.Execute(t, testCases)
+}
+
+var pythonFastapiResultVersions = []interface{}{
+	models.FormatVersion,
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.CacheRestoreVersion,
+	steps.ScriptVersion,
+	steps.ScriptVersion,
+	steps.CacheSaveVersion,
+	steps.DeployToBitriseIoVersion,
+}
+
+var pythonFastapiResultYML = fmt.Sprintf(`options:
+  python:
+    title: Python Project Directory
+    summary: The directory containing the Python project files (requirements.txt,
+      pyproject.toml, etc.)
+    env_key: PYTHON_PROJECT_DIR
+    type: selector
+    value_map:
+      .:
+        config: python-root-pip-pytest-config
+configs:
+  python:
+    python-root-pip-pytest-config: |
+      format_version: "%s"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: python
+      meta:
+        bitrise.io/framework: fastapi
+      workflows:
+        run_tests:
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - restore-cache@%s:
+              inputs:
+              - key: pip-{{ checksum "requirements.txt" }}
+          - script@%s:
+              title: Install dependencies
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  pip install -r requirements.txt
+          - script@%s:
+              title: Run tests
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  pytest
+          - save-cache@%s:
+              inputs:
+              - key: pip-{{ checksum "requirements.txt" }}
+              - paths: ~/.cache/pip
+          - deploy-to-bitrise-io@%s: {}
+      tools:
+        python: "3.12"
+warnings:
+  python: []
+warnings_with_recommendations:
+  python: []`,
+	pythonFastapiResultVersions...)

--- a/_tests/integration/python_test.go
+++ b/_tests/integration/python_test.go
@@ -88,6 +88,7 @@ configs:
                   #!/usr/bin/env bash
                   set -euxo pipefail
 
+                  pip install --upgrade pip
                   pip install -r requirements.txt
                   pip install -r requirements-dev.txt
               - working_dir: $PYTHON_PROJECT_DIR
@@ -127,7 +128,7 @@ configs:
                   set -euxo pipefail
 
                   pip install poetry
-                  poetry install
+                  poetry install --no-root
               - working_dir: $PYTHON_PROJECT_DIR
           - script@%s:
               title: Run tests

--- a/_tests/integration/python_test.go
+++ b/_tests/integration/python_test.go
@@ -12,12 +12,11 @@ import (
 func TestPython(t *testing.T) {
 	var testCases = []helper.TestCase{
 		{
-			Name:              "fastapi-sample",
-			RepoURL:           "https://github.com/bitrise-io/python-samples.git",
-			RelativeSearchDir: "fastapi-sample",
-			Branch:            "main",
-			ExpectedResult:    pythonFastapiResultYML,
-			ExpectedVersions:  pythonFastapiResultVersions,
+			Name:             "fastapi-sample",
+			RepoURL:          "https://github.com/bitrise-io/python-samples.git",
+			Branch:           "main",
+			ExpectedResult:   pythonFastapiResultYML,
+			ExpectedVersions: pythonFastapiResultVersions,
 		},
 	}
 
@@ -43,11 +42,11 @@ var pythonFastapiResultYML = fmt.Sprintf(`options:
     env_key: PYTHON_PROJECT_DIR
     type: selector
     value_map:
-      .:
-        config: python-root-pip-pytest-config
+      fastapi-sample:
+        config: python-pip-pytest-config
 configs:
   python:
-    python-root-pip-pytest-config: |
+    python-pip-pytest-config: |
       format_version: "%s"
       default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
       project_type: python
@@ -67,6 +66,8 @@ configs:
                   set -euxo pipefail
 
                   pip install -r requirements.txt
+                  pip install -r requirements-dev.txt
+              - working_dir: $PYTHON_PROJECT_DIR
           - script@%s:
               title: Run tests
               inputs:
@@ -75,6 +76,7 @@ configs:
                   set -euxo pipefail
 
                   pytest
+              - working_dir: $PYTHON_PROJECT_DIR
           - save-cache@%s:
               inputs:
               - key: pip-{{ checksum "requirements.txt" }}

--- a/_tests/integration/python_test.go
+++ b/_tests/integration/python_test.go
@@ -126,6 +126,7 @@ configs:
                   #!/usr/bin/env bash
                   set -euxo pipefail
 
+                  pip install poetry
                   poetry install
               - working_dir: $PYTHON_PROJECT_DIR
           - script@%s:
@@ -163,6 +164,7 @@ configs:
                   #!/usr/bin/env bash
                   set -euxo pipefail
 
+                  pip install uv
                   uv sync
               - working_dir: $PYTHON_PROJECT_DIR
           - script@%s:

--- a/_tests/integration/python_test.go
+++ b/_tests/integration/python_test.go
@@ -24,6 +24,25 @@ func TestPython(t *testing.T) {
 }
 
 var pythonFastapiResultVersions = []interface{}{
+	// python-pip-pytest-config
+	models.FormatVersion,
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.CacheRestoreVersion,
+	steps.ScriptVersion,
+	steps.ScriptVersion,
+	steps.CacheSaveVersion,
+	steps.DeployToBitriseIoVersion,
+	// python-poetry-pytest-config
+	models.FormatVersion,
+	steps.ActivateSSHKeyVersion,
+	steps.GitCloneVersion,
+	steps.CacheRestoreVersion,
+	steps.ScriptVersion,
+	steps.ScriptVersion,
+	steps.CacheSaveVersion,
+	steps.DeployToBitriseIoVersion,
+	// python-uv-pytest-config
 	models.FormatVersion,
 	steps.ActivateSSHKeyVersion,
 	steps.GitCloneVersion,
@@ -42,8 +61,12 @@ var pythonFastapiResultYML = fmt.Sprintf(`options:
     env_key: PYTHON_PROJECT_DIR
     type: selector
     value_map:
-      fastapi-sample:
+      fastapi-pip-sample:
         config: python-pip-pytest-config
+      fastapi-poetry-sample:
+        config: python-poetry-pytest-config
+      fastapi-uv-sample:
+        config: python-uv-pytest-config
 configs:
   python:
     python-pip-pytest-config: |
@@ -81,6 +104,80 @@ configs:
               inputs:
               - key: pip-{{ checksum "requirements.txt" }}
               - paths: ~/.cache/pip
+          - deploy-to-bitrise-io@%s: {}
+      tools:
+        python: "3.14"
+    python-poetry-pytest-config: |
+      format_version: "%s"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: python
+      workflows:
+        run_tests:
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - restore-cache@%s:
+              inputs:
+              - key: poetry-{{ checksum "poetry.lock" }}
+          - script@%s:
+              title: Install dependencies
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  poetry install
+              - working_dir: $PYTHON_PROJECT_DIR
+          - script@%s:
+              title: Run tests
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  poetry run pytest
+              - working_dir: $PYTHON_PROJECT_DIR
+          - save-cache@%s:
+              inputs:
+              - key: poetry-{{ checksum "poetry.lock" }}
+              - paths: ~/.cache/pypoetry
+          - deploy-to-bitrise-io@%s: {}
+      tools:
+        python: "3.12"
+    python-uv-pytest-config: |
+      format_version: "%s"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: python
+      workflows:
+        run_tests:
+          steps:
+          - activate-ssh-key@%s: {}
+          - git-clone@%s: {}
+          - restore-cache@%s:
+              inputs:
+              - key: uv-{{ checksum "uv.lock" }}
+          - script@%s:
+              title: Install dependencies
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  uv sync
+              - working_dir: $PYTHON_PROJECT_DIR
+          - script@%s:
+              title: Run tests
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  set -euxo pipefail
+
+                  uv run pytest
+              - working_dir: $PYTHON_PROJECT_DIR
+          - save-cache@%s:
+              inputs:
+              - key: uv-{{ checksum "uv.lock" }}
+              - paths: ~/.cache/uv
           - deploy-to-bitrise-io@%s: {}
       tools:
         python: "3.12"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/beevik/etree v1.2.0
 	github.com/bitrise-io/bitrise/v2 v2.39.1
 	github.com/bitrise-io/envman/v2 v2.5.6
-	github.com/bitrise-io/go-flutter v0.1.2-0.20260413123617-d1289effff65
+	github.com/bitrise-io/go-flutter v0.2.1-0.20260428141131-b93699c0adfe
 	github.com/bitrise-io/go-steputils v1.0.6
 	github.com/bitrise-io/go-utils v1.0.15
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.33

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/beevik/etree v1.2.0
 	github.com/bitrise-io/bitrise/v2 v2.39.1
 	github.com/bitrise-io/envman/v2 v2.5.6
-	github.com/bitrise-io/go-flutter v0.2.1-0.20260428141131-b93699c0adfe
+	github.com/bitrise-io/go-flutter v0.3.0
 	github.com/bitrise-io/go-steputils v1.0.6
 	github.com/bitrise-io/go-utils v1.0.15
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.33

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/bitrise-io/bitrise/v2 v2.39.1 h1:Cvxt+xyaMJdjGHWAhAI5om/t8H0HkpEwTpAD
 github.com/bitrise-io/bitrise/v2 v2.39.1/go.mod h1:CJVf5qRIXUcQsdNz5g5Rsbo3iQUdi9zmUOKZeijQlg8=
 github.com/bitrise-io/envman/v2 v2.5.6 h1:B3mAGc454EenkTGd1o/QDbw1WxRLJZfw9L47D2auUIE=
 github.com/bitrise-io/envman/v2 v2.5.6/go.mod h1:JJjnW87+zJj0Ft4QxuouiIJ40Ir8ZYQ8T3wVnAcpvW0=
-github.com/bitrise-io/go-flutter v0.1.2-0.20260413123617-d1289effff65 h1:O3uNNcdmpv6gVVKw4URB+VCLtOPy5ufT7kUu3BNtp+w=
-github.com/bitrise-io/go-flutter v0.1.2-0.20260413123617-d1289effff65/go.mod h1:FJyNN3BaI4ifHNaDO8bfkBgFroeybXUczEpOYuBlENo=
+github.com/bitrise-io/go-flutter v0.2.1-0.20260428141131-b93699c0adfe h1:WVpycdZVZjvI0Brz9BGniJNcSP8rMMAPkJzy1yfmiFE=
+github.com/bitrise-io/go-flutter v0.2.1-0.20260428141131-b93699c0adfe/go.mod h1:FJyNN3BaI4ifHNaDO8bfkBgFroeybXUczEpOYuBlENo=
 github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10 h1:/2OyBFI7GjYKexBPcfTPvKFz8Ks7qYzkkz2SQ8aiJgc=
 github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10/go.mod h1:pARutiL3kEuRLV3JvswidvfCj+9Y3qMZtji2BDqLFsA=
 github.com/bitrise-io/go-steputils v1.0.6 h1:eBRL70DWwEd7DWYGd5Ds7OSIY5HElzhoDOI6UuITKQg=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/bitrise-io/bitrise/v2 v2.39.1 h1:Cvxt+xyaMJdjGHWAhAI5om/t8H0HkpEwTpAD
 github.com/bitrise-io/bitrise/v2 v2.39.1/go.mod h1:CJVf5qRIXUcQsdNz5g5Rsbo3iQUdi9zmUOKZeijQlg8=
 github.com/bitrise-io/envman/v2 v2.5.6 h1:B3mAGc454EenkTGd1o/QDbw1WxRLJZfw9L47D2auUIE=
 github.com/bitrise-io/envman/v2 v2.5.6/go.mod h1:JJjnW87+zJj0Ft4QxuouiIJ40Ir8ZYQ8T3wVnAcpvW0=
-github.com/bitrise-io/go-flutter v0.2.1-0.20260428141131-b93699c0adfe h1:WVpycdZVZjvI0Brz9BGniJNcSP8rMMAPkJzy1yfmiFE=
-github.com/bitrise-io/go-flutter v0.2.1-0.20260428141131-b93699c0adfe/go.mod h1:FJyNN3BaI4ifHNaDO8bfkBgFroeybXUczEpOYuBlENo=
+github.com/bitrise-io/go-flutter v0.3.0 h1:7uOFifbYW0s/RNvPcA8OunGQFB+e3nls1XBdxxC6jww=
+github.com/bitrise-io/go-flutter v0.3.0/go.mod h1:FJyNN3BaI4ifHNaDO8bfkBgFroeybXUczEpOYuBlENo=
 github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10 h1:/2OyBFI7GjYKexBPcfTPvKFz8Ks7qYzkkz2SQ8aiJgc=
 github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10/go.mod h1:pARutiL3kEuRLV3JvswidvfCj+9Y3qMZtji2BDqLFsA=
 github.com/bitrise-io/go-steputils v1.0.6 h1:eBRL70DWwEd7DWYGd5Ds7OSIY5HElzhoDOI6UuITKQg=

--- a/scanners/python/config.go
+++ b/scanners/python/config.go
@@ -56,7 +56,6 @@ type configDescriptor struct {
 	workdir        string
 	packageManager string
 	hasPytest      bool
-	hasUnittest    bool
 	pythonVersion  string
 	framework      string
 	isDefault      bool
@@ -66,9 +65,8 @@ func createConfigDescriptor(proj project, isDefault bool) configDescriptor {
 	d := configDescriptor{
 		workdir:        "$" + projectDirInputEnvKey,
 		packageManager: proj.packageManager,
-		hasPytest:      proj.hasPytest,
-		hasUnittest:    proj.hasUnittest,
-		pythonVersion:  proj.pythonVersion,
+		hasPytest:     proj.hasPytest,
+		pythonVersion: proj.pythonVersion,
 		framework:      proj.framework,
 		isDefault:      isDefault,
 	}
@@ -98,8 +96,6 @@ func configName(d configDescriptor) string {
 	name += "-" + d.packageManager
 	if d.hasPytest {
 		name += "-pytest"
-	} else if d.hasUnittest {
-		name += "-unittest"
 	}
 	return name + "-config"
 }

--- a/scanners/python/config.go
+++ b/scanners/python/config.go
@@ -57,7 +57,6 @@ type configDescriptor struct {
 	packageManager string
 	hasPytest      bool
 	pythonVersion  string
-	framework      string
 	isDefault      bool
 }
 
@@ -67,7 +66,6 @@ func createConfigDescriptor(proj project, isDefault bool) configDescriptor {
 		packageManager: proj.packageManager,
 		hasPytest:     proj.hasPytest,
 		pythonVersion: proj.pythonVersion,
-		framework:      proj.framework,
 		isDefault:      isDefault,
 	}
 	if proj.projectRelDir == "." {
@@ -191,10 +189,6 @@ func generateConfigBasedOn(d configDescriptor, sshKey models.SSHKeyActivation) (
 	bitriseConfig, err := configBuilder.Generate(scannerName)
 	if err != nil {
 		return "", err
-	}
-
-	if d.framework != "" {
-		bitriseConfig.Meta = map[string]interface{}{"bitrise.io/framework": d.framework}
 	}
 
 	data, err := yaml.Marshal(bitriseConfig)

--- a/scanners/python/config.go
+++ b/scanners/python/config.go
@@ -1,0 +1,217 @@
+package python
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/bitrise-io/bitrise-init/models"
+	"github.com/bitrise-io/bitrise-init/steps"
+	envmanModels "github.com/bitrise-io/envman/v2/models"
+)
+
+const (
+	runTestsWorkflowID = models.WorkflowID("run_tests")
+
+	pipCacheKey   = `pip-{{ checksum "requirements.txt" }}`
+	pipCachePaths = "~/.cache/pip"
+
+	poestryCacheKey   = `poetry-{{ checksum "poetry.lock" }}`
+	poestryCachePaths = "~/.cache/pypoetry"
+)
+
+const (
+	pythonVersionInstallScriptContent = `#!/usr/bin/env bash
+set -euxo pipefail
+
+bitrise tools install python $PYTHON_VERSION
+`
+
+	pipInstallScriptContent = `#!/usr/bin/env bash
+set -euxo pipefail
+
+pip install -r requirements.txt
+`
+
+	pytestRunScriptContent = `#!/usr/bin/env bash
+set -euxo pipefail
+
+pytest
+`
+
+	poetryInstallScriptContent = `#!/usr/bin/env bash
+set -euxo pipefail
+
+poetry install
+`
+
+	poetryPytestRunScriptContent = `#!/usr/bin/env bash
+set -euxo pipefail
+
+poetry run pytest
+`
+)
+
+type configDescriptor struct {
+	workdir        string
+	packageManager string
+	hasPytest      bool
+	hasUnittest    bool
+	pythonVersion  string
+	framework      string
+	isDefault      bool
+}
+
+func createConfigDescriptor(proj project, isDefault bool) configDescriptor {
+	d := configDescriptor{
+		workdir:        "$" + projectDirInputEnvKey,
+		packageManager: proj.packageManager,
+		hasPytest:      proj.hasPytest,
+		hasUnittest:    proj.hasUnittest,
+		pythonVersion:  proj.pythonVersion,
+		framework:      proj.framework,
+		isDefault:      isDefault,
+	}
+	if proj.projectRelDir == "." {
+		d.workdir = ""
+	}
+	return d
+}
+
+func createDefaultConfigDescriptor(packageManager string) configDescriptor {
+	return createConfigDescriptor(project{
+		projectRelDir:  "$" + projectDirInputEnvKey,
+		packageManager: packageManager,
+		hasPytest:      true,
+	}, true)
+}
+
+func configName(d configDescriptor) string {
+	if d.isDefault {
+		return "default-python-" + d.packageManager + "-config"
+	}
+
+	name := "python"
+	if d.workdir == "" {
+		name += "-root"
+	}
+	name += "-" + d.packageManager
+	if d.hasPytest {
+		name += "-pytest"
+	} else if d.hasUnittest {
+		name += "-unittest"
+	}
+	return name + "-config"
+}
+
+func generateOptions(projects []project) (models.OptionNode, models.Warnings, models.Icons, error) {
+	if len(projects) == 0 {
+		return models.OptionNode{}, nil, nil, fmt.Errorf("no Python project files found")
+	}
+
+	projectRootOption := models.NewOption(projectDirInputTitle, projectDirInputSummary, projectDirInputEnvKey, models.TypeSelector)
+	for _, proj := range projects {
+		if proj.packageManager != "" {
+			descriptor := createConfigDescriptor(proj, false)
+			configOption := models.NewConfigOption(configName(descriptor), nil)
+			projectRootOption.AddConfig(proj.projectRelDir, configOption)
+		} else {
+			pkgMgrOption := models.NewOption(packageManagerInputTitle, packageManagerInputSummary, "", models.TypeSelector)
+			for _, pm := range packageManagers {
+				descriptor := createConfigDescriptor(proj, false)
+				descriptor.packageManager = pm
+				configOption := models.NewConfigOption(configName(descriptor), nil)
+				pkgMgrOption.AddConfig(pm, configOption)
+			}
+			projectRootOption.AddOption(proj.projectRelDir, pkgMgrOption)
+		}
+	}
+
+	return *projectRootOption, nil, nil, nil
+}
+
+func generateConfigs(projects []project, sshKeyActivation models.SSHKeyActivation) (models.BitriseConfigMap, error) {
+	if len(projects) == 0 {
+		return models.BitriseConfigMap{}, fmt.Errorf("no Python project files found")
+	}
+
+	configs := models.BitriseConfigMap{}
+	for _, proj := range projects {
+		if proj.packageManager != "" {
+			descriptor := createConfigDescriptor(proj, false)
+			config, err := generateConfigBasedOn(descriptor, sshKeyActivation)
+			if err != nil {
+				return nil, err
+			}
+			configs[configName(descriptor)] = config
+		} else {
+			for _, pm := range packageManagers {
+				descriptor := createConfigDescriptor(proj, false)
+				descriptor.packageManager = pm
+				config, err := generateConfigBasedOn(descriptor, sshKeyActivation)
+				if err != nil {
+					return nil, err
+				}
+				configs[configName(descriptor)] = config
+			}
+		}
+	}
+	return configs, nil
+}
+
+func generateConfigBasedOn(d configDescriptor, sshKey models.SSHKeyActivation) (string, error) {
+	configBuilder := models.NewDefaultConfigBuilder()
+
+	if d.pythonVersion != "" {
+		configBuilder.AddTool("python", d.pythonVersion)
+	}
+
+	prepareSteps := steps.DefaultPrepareStepList(steps.PrepareListParams{SSHKeyActivation: sshKey})
+	configBuilder.AppendStepListItemsTo(runTestsWorkflowID, prepareSteps...)
+
+	if d.isDefault {
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Install Python", pythonVersionInstallScriptContent))
+	}
+
+	switch d.packageManager {
+	case "poetry":
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreCache(poestryCacheKey))
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Install dependencies", poetryInstallScriptContent, workdirInputs(d.workdir)...))
+		if d.hasPytest {
+			configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Run tests", poetryPytestRunScriptContent, workdirInputs(d.workdir)...))
+		}
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.SaveCache(poestryCacheKey, poestryCachePaths))
+	default: // pip
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreCache(pipCacheKey))
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Install dependencies", pipInstallScriptContent, workdirInputs(d.workdir)...))
+		if d.hasPytest {
+			configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Run tests", pytestRunScriptContent, workdirInputs(d.workdir)...))
+		}
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.SaveCache(pipCacheKey, pipCachePaths))
+	}
+
+	configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.DefaultDeployStepList()...)
+
+	bitriseConfig, err := configBuilder.Generate(scannerName)
+	if err != nil {
+		return "", err
+	}
+
+	if d.framework != "" {
+		bitriseConfig.Meta = map[string]interface{}{"bitrise.io/framework": d.framework}
+	}
+
+	data, err := yaml.Marshal(bitriseConfig)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+func workdirInputs(workdir string) []envmanModels.EnvironmentItemModel {
+	if workdir == "" {
+		return nil
+	}
+	return []envmanModels.EnvironmentItemModel{{"working_dir": workdir}}
+}

--- a/scanners/python/config.go
+++ b/scanners/python/config.go
@@ -51,6 +51,7 @@ pytest
 	poetryInstallScriptContent = `#!/usr/bin/env bash
 set -euxo pipefail
 
+pip install poetry
 poetry install
 `
 
@@ -63,6 +64,7 @@ poetry run pytest
 	uvSyncScriptContent = `#!/usr/bin/env bash
 set -euxo pipefail
 
+pip install uv
 uv sync
 `
 

--- a/scanners/python/config.go
+++ b/scanners/python/config.go
@@ -13,15 +13,14 @@ import (
 const (
 	runTestsWorkflowID = models.WorkflowID("run_tests")
 
-	pipCacheKey   = `pip-{{ checksum "requirements.txt" }}`
-	pipCachePaths = "~/.cache/pip"
-
-	poestryCacheKey   = `poetry-{{ checksum "poetry.lock" }}`
+	pipCachePaths     = "~/.cache/pip"
 	poestryCachePaths = "~/.cache/pypoetry"
-
-	uvCacheKey   = `uv-{{ checksum "uv.lock" }}`
-	uvCachePaths = "~/.cache/uv"
+	uvCachePaths      = "~/.cache/uv"
 )
+
+func cacheKey(prefix, lockFile string) string {
+	return fmt.Sprintf(`%s-{{ checksum "%s" }}`, prefix, lockFile)
+}
 
 const (
 	pythonVersionInstallScriptContent = `#!/usr/bin/env bash
@@ -33,11 +32,13 @@ bitrise tools install python $PYTHON_VERSION
 	pipInstallScriptContent = `#!/usr/bin/env bash
 set -euxo pipefail
 
+pip install --upgrade pip
 pip install -r requirements.txt
 `
 	pipInstallWithDevScriptTemplate = `#!/usr/bin/env bash
 set -euxo pipefail
 
+pip install --upgrade pip
 pip install -r requirements.txt
 pip install -r %s
 `
@@ -53,6 +54,13 @@ set -euxo pipefail
 
 pip install poetry
 poetry install
+`
+
+	poetryInstallNoRootScriptContent = `#!/usr/bin/env bash
+set -euxo pipefail
+
+pip install poetry
+poetry install --no-root
 `
 
 	poetryPytestRunScriptContent = `#!/usr/bin/env bash
@@ -81,6 +89,7 @@ type configDescriptor struct {
 	hasPytest           bool
 	pythonVersion       string
 	devRequirementsFile string
+	poetryNeedsNoRoot   bool
 	isDefault           bool
 }
 
@@ -91,6 +100,7 @@ func createConfigDescriptor(proj project, isDefault bool) configDescriptor {
 		hasPytest:           proj.hasPytest,
 		pythonVersion:       proj.pythonVersion,
 		devRequirementsFile: proj.devRequirementsFile,
+		poetryNeedsNoRoot:   proj.poetryNeedsNoRoot,
 		isDefault:           isDefault,
 	}
 	if proj.projectRelDir == "." {
@@ -101,9 +111,10 @@ func createConfigDescriptor(proj project, isDefault bool) configDescriptor {
 
 func createDefaultConfigDescriptor(packageManager string) configDescriptor {
 	return createConfigDescriptor(project{
-		projectRelDir:  "$" + projectDirInputEnvKey,
-		packageManager: packageManager,
-		hasPytest:      true,
+		projectRelDir:     "$" + projectDirInputEnvKey,
+		packageManager:    packageManager,
+		hasPytest:         true,
+		poetryNeedsNoRoot: true,
 	}, true)
 }
 
@@ -194,21 +205,28 @@ func generateConfigBasedOn(d configDescriptor, sshKey models.SSHKeyActivation) (
 
 	switch d.packageManager {
 	case "uv":
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreCache(uvCacheKey))
+		key := cacheKey("uv", "uv.lock")
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreCache(key))
 		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Install dependencies", uvSyncScriptContent, workdirInputs(d.workdir)...))
 		if d.hasPytest {
 			configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Run tests", uvPytestRunScriptContent, workdirInputs(d.workdir)...))
 		}
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.SaveCache(uvCacheKey, uvCachePaths))
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.SaveCache(key, uvCachePaths))
 	case "poetry":
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreCache(poestryCacheKey))
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Install dependencies", poetryInstallScriptContent, workdirInputs(d.workdir)...))
+		key := cacheKey("poetry", "poetry.lock")
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreCache(key))
+		installScript := poetryInstallScriptContent
+		if d.poetryNeedsNoRoot {
+			installScript = poetryInstallNoRootScriptContent
+		}
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Install dependencies", installScript, workdirInputs(d.workdir)...))
 		if d.hasPytest {
 			configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Run tests", poetryPytestRunScriptContent, workdirInputs(d.workdir)...))
 		}
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.SaveCache(poestryCacheKey, poestryCachePaths))
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.SaveCache(key, poestryCachePaths))
 	default: // pip
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreCache(pipCacheKey))
+		key := cacheKey("pip", "requirements.txt")
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreCache(key))
 		pipInstall := pipInstallScriptContent
 		if d.devRequirementsFile != "" {
 			pipInstall = fmt.Sprintf(pipInstallWithDevScriptTemplate, d.devRequirementsFile)
@@ -217,7 +235,7 @@ func generateConfigBasedOn(d configDescriptor, sshKey models.SSHKeyActivation) (
 		if d.hasPytest {
 			configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Run tests", pytestRunScriptContent, workdirInputs(d.workdir)...))
 		}
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.SaveCache(pipCacheKey, pipCachePaths))
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.SaveCache(key, pipCachePaths))
 	}
 
 	configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.DefaultDeployStepList()...)

--- a/scanners/python/config.go
+++ b/scanners/python/config.go
@@ -13,16 +13,10 @@ import (
 const (
 	runTestsWorkflowID = models.WorkflowID("run_tests")
 
-	pipCachePaths     = "~/.cache/pip"
-	poestryCachePaths = "~/.cache/pypoetry"
-	uvCachePaths      = "~/.cache/uv"
-)
+	pipCachePaths    = "~/.cache/pip"
+	poetryCachePaths = "~/.cache/pypoetry"
+	uvCachePaths     = "~/.cache/uv"
 
-func cacheKey(prefix, lockFile string) string {
-	return fmt.Sprintf(`%s-{{ checksum "%s" }}`, prefix, lockFile)
-}
-
-const (
 	pythonVersionInstallScriptContent = `#!/usr/bin/env bash
 set -euxo pipefail
 
@@ -93,6 +87,18 @@ type configDescriptor struct {
 	isDefault           bool
 }
 
+// packageManagerSetup holds the per-package-manager bits used by the run_tests
+// workflow: cache config (key prefix + lockfile + paths) and install/test
+// scripts. generateConfigBasedOn resolves one of these and then runs a uniform
+// restore-install-test-save sequence.
+type packageManagerSetup struct {
+	cacheKeyPrefix string
+	cacheLockFile  string
+	cachePaths     string
+	installScript  string
+	testScript     string
+}
+
 func createConfigDescriptor(proj project, isDefault bool) configDescriptor {
 	d := configDescriptor{
 		workdir:             "$" + projectDirInputEnvKey,
@@ -116,22 +122,6 @@ func createDefaultConfigDescriptor(packageManager string) configDescriptor {
 		hasPytest:         true,
 		poetryNeedsNoRoot: true,
 	}, true)
-}
-
-func configName(d configDescriptor) string {
-	if d.isDefault {
-		return "default-python-" + d.packageManager + "-config"
-	}
-
-	name := "python"
-	if d.workdir == "" {
-		name += "-root"
-	}
-	name += "-" + d.packageManager
-	if d.hasPytest {
-		name += "-pytest"
-	}
-	return name + "-config"
 }
 
 func generateOptions(projects []project) (models.OptionNode, models.Warnings, models.Icons, error) {
@@ -189,6 +179,22 @@ func generateConfigs(projects []project, sshKeyActivation models.SSHKeyActivatio
 	return configs, nil
 }
 
+func configName(d configDescriptor) string {
+	if d.isDefault {
+		return "default-python-" + d.packageManager + "-config"
+	}
+
+	name := "python"
+	if d.workdir == "" {
+		name += "-root"
+	}
+	name += "-" + d.packageManager
+	if d.hasPytest {
+		name += "-pytest"
+	}
+	return name + "-config"
+}
+
 func generateConfigBasedOn(d configDescriptor, sshKey models.SSHKeyActivation) (string, error) {
 	configBuilder := models.NewDefaultConfigBuilder()
 
@@ -203,40 +209,14 @@ func generateConfigBasedOn(d configDescriptor, sshKey models.SSHKeyActivation) (
 		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Install Python", pythonVersionInstallScriptContent))
 	}
 
-	switch d.packageManager {
-	case "uv":
-		key := cacheKey("uv", "uv.lock")
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreCache(key))
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Install dependencies", uvSyncScriptContent, workdirInputs(d.workdir)...))
-		if d.hasPytest {
-			configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Run tests", uvPytestRunScriptContent, workdirInputs(d.workdir)...))
-		}
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.SaveCache(key, uvCachePaths))
-	case "poetry":
-		key := cacheKey("poetry", "poetry.lock")
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreCache(key))
-		installScript := poetryInstallScriptContent
-		if d.poetryNeedsNoRoot {
-			installScript = poetryInstallNoRootScriptContent
-		}
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Install dependencies", installScript, workdirInputs(d.workdir)...))
-		if d.hasPytest {
-			configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Run tests", poetryPytestRunScriptContent, workdirInputs(d.workdir)...))
-		}
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.SaveCache(key, poestryCachePaths))
-	default: // pip
-		key := cacheKey("pip", "requirements.txt")
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreCache(key))
-		pipInstall := pipInstallScriptContent
-		if d.devRequirementsFile != "" {
-			pipInstall = fmt.Sprintf(pipInstallWithDevScriptTemplate, d.devRequirementsFile)
-		}
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Install dependencies", pipInstall, workdirInputs(d.workdir)...))
-		if d.hasPytest {
-			configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Run tests", pytestRunScriptContent, workdirInputs(d.workdir)...))
-		}
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.SaveCache(key, pipCachePaths))
+	setup := packageManagerSetupFor(d)
+	key := cacheKey(setup.cacheKeyPrefix, setup.cacheLockFile)
+	configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreCache(key))
+	configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Install dependencies", setup.installScript, workdirInputs(d.workdir)...))
+	if d.hasPytest {
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Run tests", setup.testScript, workdirInputs(d.workdir)...))
 	}
+	configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.SaveCache(key, setup.cachePaths))
 
 	configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.DefaultDeployStepList()...)
 
@@ -251,6 +231,47 @@ func generateConfigBasedOn(d configDescriptor, sshKey models.SSHKeyActivation) (
 	}
 
 	return string(data), nil
+}
+
+func packageManagerSetupFor(d configDescriptor) packageManagerSetup {
+	switch d.packageManager {
+	case "uv":
+		return packageManagerSetup{
+			cacheKeyPrefix: "uv",
+			cacheLockFile:  "uv.lock",
+			cachePaths:     uvCachePaths,
+			installScript:  uvSyncScriptContent,
+			testScript:     uvPytestRunScriptContent,
+		}
+	case "poetry":
+		install := poetryInstallScriptContent
+		if d.poetryNeedsNoRoot {
+			install = poetryInstallNoRootScriptContent
+		}
+		return packageManagerSetup{
+			cacheKeyPrefix: "poetry",
+			cacheLockFile:  "poetry.lock",
+			cachePaths:     poetryCachePaths,
+			installScript:  install,
+			testScript:     poetryPytestRunScriptContent,
+		}
+	default: // pip
+		install := pipInstallScriptContent
+		if d.devRequirementsFile != "" {
+			install = fmt.Sprintf(pipInstallWithDevScriptTemplate, d.devRequirementsFile)
+		}
+		return packageManagerSetup{
+			cacheKeyPrefix: "pip",
+			cacheLockFile:  "requirements.txt",
+			cachePaths:     pipCachePaths,
+			installScript:  install,
+			testScript:     pytestRunScriptContent,
+		}
+	}
+}
+
+func cacheKey(prefix, lockFile string) string {
+	return fmt.Sprintf(`%s-{{ checksum "%s" }}`, prefix, lockFile)
 }
 
 func workdirInputs(workdir string) []envmanModels.EnvironmentItemModel {

--- a/scanners/python/config.go
+++ b/scanners/python/config.go
@@ -18,6 +18,9 @@ const (
 
 	poestryCacheKey   = `poetry-{{ checksum "poetry.lock" }}`
 	poestryCachePaths = "~/.cache/pypoetry"
+
+	uvCacheKey   = `uv-{{ checksum "uv.lock" }}`
+	uvCachePaths = "~/.cache/uv"
 )
 
 const (
@@ -55,6 +58,18 @@ poetry install
 set -euxo pipefail
 
 poetry run pytest
+`
+
+	uvSyncScriptContent = `#!/usr/bin/env bash
+set -euxo pipefail
+
+uv sync
+`
+
+	uvPytestRunScriptContent = `#!/usr/bin/env bash
+set -euxo pipefail
+
+uv run pytest
 `
 )
 
@@ -176,6 +191,13 @@ func generateConfigBasedOn(d configDescriptor, sshKey models.SSHKeyActivation) (
 	}
 
 	switch d.packageManager {
+	case "uv":
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreCache(uvCacheKey))
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Install dependencies", uvSyncScriptContent, workdirInputs(d.workdir)...))
+		if d.hasPytest {
+			configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Run tests", uvPytestRunScriptContent, workdirInputs(d.workdir)...))
+		}
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.SaveCache(uvCacheKey, uvCachePaths))
 	case "poetry":
 		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreCache(poestryCacheKey))
 		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Install dependencies", poetryInstallScriptContent, workdirInputs(d.workdir)...))

--- a/scanners/python/config.go
+++ b/scanners/python/config.go
@@ -32,6 +32,12 @@ set -euxo pipefail
 
 pip install -r requirements.txt
 `
+	pipInstallWithDevScriptTemplate = `#!/usr/bin/env bash
+set -euxo pipefail
+
+pip install -r requirements.txt
+pip install -r %s
+`
 
 	pytestRunScriptContent = `#!/usr/bin/env bash
 set -euxo pipefail
@@ -53,20 +59,22 @@ poetry run pytest
 )
 
 type configDescriptor struct {
-	workdir        string
-	packageManager string
-	hasPytest      bool
-	pythonVersion  string
-	isDefault      bool
+	workdir             string
+	packageManager      string
+	hasPytest           bool
+	pythonVersion       string
+	devRequirementsFile string
+	isDefault           bool
 }
 
 func createConfigDescriptor(proj project, isDefault bool) configDescriptor {
 	d := configDescriptor{
-		workdir:        "$" + projectDirInputEnvKey,
-		packageManager: proj.packageManager,
-		hasPytest:     proj.hasPytest,
-		pythonVersion: proj.pythonVersion,
-		isDefault:      isDefault,
+		workdir:             "$" + projectDirInputEnvKey,
+		packageManager:      proj.packageManager,
+		hasPytest:           proj.hasPytest,
+		pythonVersion:       proj.pythonVersion,
+		devRequirementsFile: proj.devRequirementsFile,
+		isDefault:           isDefault,
 	}
 	if proj.projectRelDir == "." {
 		d.workdir = ""
@@ -177,7 +185,11 @@ func generateConfigBasedOn(d configDescriptor, sshKey models.SSHKeyActivation) (
 		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.SaveCache(poestryCacheKey, poestryCachePaths))
 	default: // pip
 		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.RestoreCache(pipCacheKey))
-		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Install dependencies", pipInstallScriptContent, workdirInputs(d.workdir)...))
+		pipInstall := pipInstallScriptContent
+		if d.devRequirementsFile != "" {
+			pipInstall = fmt.Sprintf(pipInstallWithDevScriptTemplate, d.devRequirementsFile)
+		}
+		configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Install dependencies", pipInstall, workdirInputs(d.workdir)...))
 		if d.hasPytest {
 			configBuilder.AppendStepListItemsTo(runTestsWorkflowID, steps.ScriptStepListItem("Run tests", pytestRunScriptContent, workdirInputs(d.workdir)...))
 		}

--- a/scanners/python/config.go
+++ b/scanners/python/config.go
@@ -233,6 +233,9 @@ func generateConfigBasedOn(d configDescriptor, sshKey models.SSHKeyActivation) (
 	return string(data), nil
 }
 
+// packageManagerSetupFor returns the cache config and scripts for the package
+// manager named in d. Pip and Poetry inject extra context (dev requirements
+// file, --no-root) from the descriptor; uv has no per-project variants.
 func packageManagerSetupFor(d configDescriptor) packageManagerSetup {
 	switch d.packageManager {
 	case "uv":

--- a/scanners/python/detection.go
+++ b/scanners/python/detection.go
@@ -1,0 +1,240 @@
+package python
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/bitrise-io/bitrise-init/utility"
+	"github.com/bitrise-io/go-utils/fileutil"
+	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/go-utils/pathutil"
+)
+
+var markerFiles = []string{
+	"requirements.txt",
+	"pyproject.toml",
+	"Pipfile",
+	"setup.py",
+}
+
+// requirementsFiles are checked in order when looking for pytest as a dependency.
+var requirementsFiles = []string{
+	"requirements.txt",
+	"requirements-dev.txt",
+	"requirements-test.txt",
+	"requirements_dev.txt",
+	"requirements_test.txt",
+}
+
+func collectPythonProjectDirs(searchDir string) ([]string, error) {
+	fileList, err := pathutil.ListPathInDirSortedByComponents(searchDir, false)
+	if err != nil {
+		return nil, err
+	}
+
+	excludeFilters := []pathutil.FilterFunc{
+		pathutil.ComponentFilter(".git", false),
+		pathutil.ComponentFilter("node_modules", false),
+		pathutil.ComponentFilter(".venv", false),
+		pathutil.ComponentFilter("venv", false),
+		pathutil.ComponentFilter("__pycache__", false),
+	}
+
+	seenDirs := map[string]bool{}
+	var projectDirs []string
+
+	for _, markerFile := range markerFiles {
+		filters := append(excludeFilters, pathutil.BaseFilter(markerFile, true))
+		paths, err := pathutil.FilterPaths(fileList, filters...)
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range paths {
+			dir := filepath.Dir(p)
+			if !seenDirs[dir] {
+				seenDirs[dir] = true
+				projectDirs = append(projectDirs, dir)
+			}
+		}
+	}
+
+	return projectDirs, nil
+}
+
+func detectPackageManager(projectDir string) string {
+	log.TPrintf("Checking package manager")
+
+	if utility.FileExists(filepath.Join(projectDir, "poetry.lock")) {
+		log.TPrintf("- poetry.lock - found")
+		return "poetry"
+	}
+
+	if utility.FileExists(filepath.Join(projectDir, "requirements.txt")) {
+		log.TPrintf("- requirements.txt - found")
+		return "pip"
+	}
+
+	log.TPrintf("- package manager - not detected")
+	return ""
+}
+
+func detectPythonVersion(projectDir string) string {
+	log.TPrintf("Checking Python version")
+
+	// .python-version — single line (e.g. "3.12")
+	if content, err := fileutil.ReadStringFromFile(filepath.Join(projectDir, ".python-version")); err == nil {
+		version := strings.TrimSpace(content)
+		if version != "" {
+			log.TPrintf("- .python-version - found (%s)", version)
+			return version
+		}
+	}
+
+	// .tool-versions — asdf/mise format: "python 3.12.x"
+	if content, err := fileutil.ReadStringFromFile(filepath.Join(projectDir, ".tool-versions")); err == nil {
+		for _, line := range strings.Split(content, "\n") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 && fields[0] == "python" {
+				log.TPrintf("- .tool-versions - found python %s", fields[1])
+				return fields[1]
+			}
+		}
+	}
+
+	// pyproject.toml — requires-python field (e.g. requires-python = ">=3.12")
+	if version := pyprojectRequiresPython(projectDir); version != "" {
+		log.TPrintf("- pyproject.toml requires-python - found (%s)", version)
+		return version
+	}
+
+	log.TPrintf("- Python version - not found")
+	return ""
+}
+
+// pyprojectRequiresPython extracts a version string from the requires-python field in pyproject.toml.
+func pyprojectRequiresPython(projectDir string) string {
+	content, err := fileutil.ReadStringFromFile(filepath.Join(projectDir, "pyproject.toml"))
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "requires-python") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		raw := strings.Trim(strings.TrimSpace(parts[1]), `"' `)
+		// Strip leading operators: >=, ==, ~=, ^, >
+		i := 0
+		for i < len(raw) {
+			c := raw[i]
+			if c == '>' || c == '<' || c == '=' || c == '~' || c == '^' || c == ' ' {
+				i++
+			} else {
+				break
+			}
+		}
+		version := strings.TrimSpace(raw[i:])
+		// Take the first token in case of compound ranges like ">=3.12,<4"
+		if parts := strings.FieldsFunc(version, func(r rune) bool { return r == ',' || r == ' ' }); len(parts) > 0 {
+			return parts[0]
+		}
+	}
+	return ""
+}
+
+func detectTestRunner(projectDir string) (hasPytest, hasUnittest bool) {
+	log.TPrintf("Checking test runner")
+
+	if utility.FileExists(filepath.Join(projectDir, "pytest.ini")) {
+		log.TPrintf("- pytest.ini - found")
+		return true, false
+	}
+
+	if utility.FileExists(filepath.Join(projectDir, "conftest.py")) {
+		log.TPrintf("- conftest.py - found")
+		return true, false
+	}
+
+	if hasPytestInPyprojectToml(projectDir) {
+		log.TPrintf("- [tool.pytest] in pyproject.toml - found")
+		return true, false
+	}
+
+	if hasPytestInRequirementsFiles(projectDir) {
+		log.TPrintf("- pytest in requirements files - found")
+		return true, false
+	}
+
+	log.TPrintf("- test runner - not detected")
+	return false, false
+}
+
+func hasPytestInPyprojectToml(projectDir string) bool {
+	content, err := fileutil.ReadStringFromFile(filepath.Join(projectDir, "pyproject.toml"))
+	if err != nil {
+		return false
+	}
+	return strings.Contains(content, "[tool.pytest")
+}
+
+func hasPytestInRequirementsFiles(projectDir string) bool {
+	for _, name := range requirementsFiles {
+		content, err := fileutil.ReadStringFromFile(filepath.Join(projectDir, name))
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(content, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "-") {
+				continue
+			}
+			pkg := packageName(line)
+			if strings.EqualFold(pkg, "pytest") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// packageName extracts the package name from a requirements.txt line by stripping version specifiers.
+func packageName(line string) string {
+	i := strings.IndexAny(line, "=<>![ ;#\t")
+	if i == -1 {
+		return line
+	}
+	return strings.TrimSpace(line[:i])
+}
+
+func detectFramework(projectDir string) string {
+	log.TPrintf("Checking framework")
+
+	frameworks := []string{"fastapi", "django", "flask"}
+
+	content, err := fileutil.ReadStringFromFile(filepath.Join(projectDir, "requirements.txt"))
+	if err != nil {
+		log.TPrintf("- framework - requirements.txt not found")
+		return ""
+	}
+
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		pkg := strings.ToLower(packageName(line))
+		for _, fw := range frameworks {
+			if pkg == fw {
+				log.TPrintf("- framework: %s", fw)
+				return fw
+			}
+		}
+	}
+
+	log.TPrintf("- framework - not detected")
+	return ""
+}

--- a/scanners/python/detection.go
+++ b/scanners/python/detection.go
@@ -146,31 +146,31 @@ func pyprojectRequiresPython(projectDir string) string {
 	return ""
 }
 
-func detectTestRunner(projectDir string) (hasPytest, hasUnittest bool) {
+func detectTestRunner(projectDir string) bool {
 	log.TPrintf("Checking test runner")
 
 	if utility.FileExists(filepath.Join(projectDir, "pytest.ini")) {
 		log.TPrintf("- pytest.ini - found")
-		return true, false
+		return true
 	}
 
 	if utility.FileExists(filepath.Join(projectDir, "conftest.py")) {
 		log.TPrintf("- conftest.py - found")
-		return true, false
+		return true
 	}
 
 	if hasPytestInPyprojectToml(projectDir) {
 		log.TPrintf("- [tool.pytest] in pyproject.toml - found")
-		return true, false
+		return true
 	}
 
 	if hasPytestInRequirementsFiles(projectDir) {
 		log.TPrintf("- pytest in requirements files - found")
-		return true, false
+		return true
 	}
 
 	log.TPrintf("- test runner - not detected")
-	return false, false
+	return false
 }
 
 func hasPytestInPyprojectToml(projectDir string) bool {

--- a/scanners/python/detection.go
+++ b/scanners/python/detection.go
@@ -27,7 +27,7 @@ var requirementsFiles = []string{
 }
 
 type pyprojectInfo struct {
-	poetryPackageModeFalse bool
+	poetryPackageModeDisabled bool
 	poetryHasPackagesField bool
 	poetryName             string
 	projectName            string
@@ -220,7 +220,7 @@ func detectPoetryNeedsNoRoot(projectDir string) bool {
 	}
 
 	info := parsePyproject(content)
-	if info.poetryPackageModeFalse {
+	if info.poetryPackageModeDisabled {
 		log.TPrintf("- package-mode = false - found, plain install")
 		return false
 	}
@@ -337,7 +337,7 @@ func parsePyproject(content string) pyprojectInfo {
 		case "[tool.poetry]":
 			if strings.HasPrefix(trimmed, "package-mode") {
 				if parts := strings.SplitN(trimmed, "=", 2); len(parts) == 2 && strings.TrimSpace(parts[1]) == "false" {
-					info.poetryPackageModeFalse = true
+					info.poetryPackageModeDisabled = true
 				}
 			}
 			if strings.HasPrefix(trimmed, "packages") && strings.Contains(trimmed, "=") {

--- a/scanners/python/detection.go
+++ b/scanners/python/detection.go
@@ -26,6 +26,13 @@ var requirementsFiles = []string{
 	"requirements_test.txt",
 }
 
+type pyprojectInfo struct {
+	poetryPackageModeFalse bool
+	poetryHasPackagesField bool
+	poetryName             string
+	projectName            string
+}
+
 func collectPythonProjectDirs(searchDir string) ([]string, error) {
 	fileList, err := pathutil.ListPathInDirSortedByComponents(searchDir, false)
 	if err != nil {
@@ -116,6 +123,133 @@ func detectPythonVersion(projectDir string) string {
 	return ""
 }
 
+func detectTestRunner(projectDir string) bool {
+	log.TPrintf("Checking test runner")
+
+	if utility.FileExists(filepath.Join(projectDir, "pytest.ini")) {
+		log.TPrintf("- pytest.ini - found")
+		return true
+	}
+
+	if utility.FileExists(filepath.Join(projectDir, "conftest.py")) {
+		log.TPrintf("- conftest.py - found")
+		return true
+	}
+
+	if hasPytestInPyprojectToml(projectDir) {
+		log.TPrintf("- [tool.pytest] in pyproject.toml - found")
+		return true
+	}
+
+	if hasPytestInRequirementsFiles(projectDir) {
+		log.TPrintf("- pytest in requirements files - found")
+		return true
+	}
+
+	log.TPrintf("- test runner - not detected")
+	return false
+}
+
+// detectDevRequirementsFile returns the first dev/test requirements file found in projectDir, or "".
+func detectDevRequirementsFile(projectDir string) string {
+	devFiles := []string{
+		"requirements-dev.txt",
+		"requirements-test.txt",
+		"requirements_dev.txt",
+		"requirements_test.txt",
+	}
+	for _, name := range devFiles {
+		if utility.FileExists(filepath.Join(projectDir, name)) {
+			log.TPrintf("- dev requirements: %s - found", name)
+			return name
+		}
+	}
+	return ""
+}
+
+// detectFramework logs which Python web framework the project uses, if any.
+// The result is only surfaced through scan logs; it doesn't affect the
+// generated workflow.
+func detectFramework(projectDir string) {
+	log.TPrintf("Checking framework")
+
+	frameworks := []string{"fastapi", "django", "flask"}
+
+	content, err := fileutil.ReadStringFromFile(filepath.Join(projectDir, "requirements.txt"))
+	if err != nil {
+		log.TPrintf("- framework - requirements.txt not found")
+		return
+	}
+
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		pkg := strings.ToLower(packageName(line))
+		for _, fw := range frameworks {
+			if pkg == fw {
+				log.TPrintf("- framework: %s", fw)
+				return
+			}
+		}
+	}
+
+	log.TPrintf("- framework - not detected")
+}
+
+// detectPoetryNeedsNoRoot decides whether `poetry install` should be invoked
+// with --no-root. Plain `poetry install` fails when poetry is in package mode
+// but the project doesn't ship an installable package, which is the common app
+// case (FastAPI/Django/Flask services). For library projects with a real
+// package layout we skip --no-root so the package is installed for tests that
+// rely on entry points or installed metadata.
+//
+// Heuristics in priority order:
+//  1. `package-mode = false` in [tool.poetry]                              -> no --no-root
+//  2. explicit `packages = ...` in [tool.poetry]                           -> no --no-root
+//  3. project name resolves to <dir>/__init__.py or src/<dir>/__init__.py  -> no --no-root
+//  4. otherwise                                                            -> use --no-root
+func detectPoetryNeedsNoRoot(projectDir string) bool {
+	content, err := fileutil.ReadStringFromFile(filepath.Join(projectDir, "pyproject.toml"))
+	if err != nil {
+		log.TPrintf("- poetry --no-root: pyproject.toml not found, defaulting to --no-root")
+		return true
+	}
+
+	info := parsePyproject(content)
+	if info.poetryPackageModeFalse {
+		log.TPrintf("- poetry --no-root: package-mode = false set, plain install")
+		return false
+	}
+	if info.poetryHasPackagesField {
+		log.TPrintf("- poetry --no-root: explicit [tool.poetry] packages declared, plain install")
+		return false
+	}
+
+	name := info.poetryName
+	if name == "" {
+		name = info.projectName
+	}
+	if name == "" {
+		log.TPrintf("- poetry --no-root: no project name found, defaulting to --no-root")
+		return true
+	}
+
+	pkgDir := strings.ReplaceAll(name, "-", "_")
+	if utility.FileExists(filepath.Join(projectDir, pkgDir, "__init__.py")) {
+		log.TPrintf("- poetry --no-root: %s/__init__.py found, plain install", pkgDir)
+		return false
+	}
+	if utility.FileExists(filepath.Join(projectDir, "src", pkgDir, "__init__.py")) {
+		log.TPrintf("- poetry --no-root: src/%s/__init__.py found, plain install", pkgDir)
+		return false
+	}
+
+	log.TPrintf("- poetry --no-root: no installable package layout, using --no-root")
+	return true
+}
+
 // pyprojectRequiresPython extracts a version string from the requires-python field in pyproject.toml.
 func pyprojectRequiresPython(projectDir string) string {
 	content, err := fileutil.ReadStringFromFile(filepath.Join(projectDir, "pyproject.toml"))
@@ -151,33 +285,6 @@ func pyprojectRequiresPython(projectDir string) string {
 	return ""
 }
 
-func detectTestRunner(projectDir string) bool {
-	log.TPrintf("Checking test runner")
-
-	if utility.FileExists(filepath.Join(projectDir, "pytest.ini")) {
-		log.TPrintf("- pytest.ini - found")
-		return true
-	}
-
-	if utility.FileExists(filepath.Join(projectDir, "conftest.py")) {
-		log.TPrintf("- conftest.py - found")
-		return true
-	}
-
-	if hasPytestInPyprojectToml(projectDir) {
-		log.TPrintf("- [tool.pytest] in pyproject.toml - found")
-		return true
-	}
-
-	if hasPytestInRequirementsFiles(projectDir) {
-		log.TPrintf("- pytest in requirements files - found")
-		return true
-	}
-
-	log.TPrintf("- test runner - not detected")
-	return false
-}
-
 func hasPytestInPyprojectToml(projectDir string) bool {
 	content, err := fileutil.ReadStringFromFile(filepath.Join(projectDir, "pyproject.toml"))
 	if err != nil {
@@ -206,23 +313,6 @@ func hasPytestInRequirementsFiles(projectDir string) bool {
 	return false
 }
 
-// detectDevRequirementsFile returns the first dev/test requirements file found in projectDir, or "".
-func detectDevRequirementsFile(projectDir string) string {
-	devFiles := []string{
-		"requirements-dev.txt",
-		"requirements-test.txt",
-		"requirements_dev.txt",
-		"requirements_test.txt",
-	}
-	for _, name := range devFiles {
-		if utility.FileExists(filepath.Join(projectDir, name)) {
-			log.TPrintf("- dev requirements: %s - found", name)
-			return name
-		}
-	}
-	return ""
-}
-
 // packageName extracts the package name from a requirements.txt line by stripping version specifiers.
 func packageName(line string) string {
 	i := strings.IndexAny(line, "=<>![ ;#\t")
@@ -230,13 +320,6 @@ func packageName(line string) string {
 		return line
 	}
 	return strings.TrimSpace(line[:i])
-}
-
-type pyprojectInfo struct {
-	poetryPackageModeFalse bool
-	poetryHasPackagesField bool
-	poetryName             string
-	projectName            string
 }
 
 func parsePyproject(content string) pyprojectInfo {
@@ -280,85 +363,4 @@ func pyprojectStringValue(line string) string {
 		return ""
 	}
 	return strings.Trim(strings.TrimSpace(parts[1]), `"'`)
-}
-
-// detectPoetryNeedsNoRoot decides whether `poetry install` should be invoked
-// with --no-root. Plain `poetry install` fails when poetry is in package mode
-// but the project doesn't ship an installable package, which is the common app
-// case (FastAPI/Django/Flask services). For library projects with a real
-// package layout we skip --no-root so the package is installed for tests that
-// rely on entry points or installed metadata.
-//
-// Heuristics in priority order:
-//  1. `package-mode = false` in [tool.poetry]                       -> no --no-root
-//  2. explicit `packages = ...` in [tool.poetry]                    -> no --no-root
-//  3. project name resolves to <dir>/__init__.py or src/<dir>/__init__.py -> no --no-root
-//  4. otherwise                                                     -> use --no-root
-func detectPoetryNeedsNoRoot(projectDir string) bool {
-	content, err := fileutil.ReadStringFromFile(filepath.Join(projectDir, "pyproject.toml"))
-	if err != nil {
-		log.TPrintf("- poetry --no-root: pyproject.toml not found, defaulting to --no-root")
-		return true
-	}
-
-	info := parsePyproject(content)
-	if info.poetryPackageModeFalse {
-		log.TPrintf("- poetry --no-root: package-mode = false set, plain install")
-		return false
-	}
-	if info.poetryHasPackagesField {
-		log.TPrintf("- poetry --no-root: explicit [tool.poetry] packages declared, plain install")
-		return false
-	}
-
-	name := info.poetryName
-	if name == "" {
-		name = info.projectName
-	}
-	if name == "" {
-		log.TPrintf("- poetry --no-root: no project name found, defaulting to --no-root")
-		return true
-	}
-
-	pkgDir := strings.ReplaceAll(name, "-", "_")
-	if utility.FileExists(filepath.Join(projectDir, pkgDir, "__init__.py")) {
-		log.TPrintf("- poetry --no-root: %s/__init__.py found, plain install", pkgDir)
-		return false
-	}
-	if utility.FileExists(filepath.Join(projectDir, "src", pkgDir, "__init__.py")) {
-		log.TPrintf("- poetry --no-root: src/%s/__init__.py found, plain install", pkgDir)
-		return false
-	}
-
-	log.TPrintf("- poetry --no-root: no installable package layout, using --no-root")
-	return true
-}
-
-func detectFramework(projectDir string) string {
-	log.TPrintf("Checking framework")
-
-	frameworks := []string{"fastapi", "django", "flask"}
-
-	content, err := fileutil.ReadStringFromFile(filepath.Join(projectDir, "requirements.txt"))
-	if err != nil {
-		log.TPrintf("- framework - requirements.txt not found")
-		return ""
-	}
-
-	for _, line := range strings.Split(content, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		pkg := strings.ToLower(packageName(line))
-		for _, fw := range frameworks {
-			if pkg == fw {
-				log.TPrintf("- framework: %s", fw)
-				return fw
-			}
-		}
-	}
-
-	log.TPrintf("- framework - not detected")
-	return ""
 }

--- a/scanners/python/detection.go
+++ b/scanners/python/detection.go
@@ -211,19 +211,21 @@ func detectFramework(projectDir string) {
 //  3. project name resolves to <dir>/__init__.py or src/<dir>/__init__.py  -> no --no-root
 //  4. otherwise                                                            -> use --no-root
 func detectPoetryNeedsNoRoot(projectDir string) bool {
+	log.TPrintf("Checking Poetry --no-root requirement")
+
 	content, err := fileutil.ReadStringFromFile(filepath.Join(projectDir, "pyproject.toml"))
 	if err != nil {
-		log.TPrintf("- poetry --no-root: pyproject.toml not found, defaulting to --no-root")
+		log.TPrintf("- pyproject.toml - not found, using --no-root")
 		return true
 	}
 
 	info := parsePyproject(content)
 	if info.poetryPackageModeFalse {
-		log.TPrintf("- poetry --no-root: package-mode = false set, plain install")
+		log.TPrintf("- package-mode = false - found, plain install")
 		return false
 	}
 	if info.poetryHasPackagesField {
-		log.TPrintf("- poetry --no-root: explicit [tool.poetry] packages declared, plain install")
+		log.TPrintf("- [tool.poetry] packages - declared, plain install")
 		return false
 	}
 
@@ -232,21 +234,21 @@ func detectPoetryNeedsNoRoot(projectDir string) bool {
 		name = info.projectName
 	}
 	if name == "" {
-		log.TPrintf("- poetry --no-root: no project name found, defaulting to --no-root")
+		log.TPrintf("- project name - not found, using --no-root")
 		return true
 	}
 
 	pkgDir := strings.ReplaceAll(name, "-", "_")
 	if utility.FileExists(filepath.Join(projectDir, pkgDir, "__init__.py")) {
-		log.TPrintf("- poetry --no-root: %s/__init__.py found, plain install", pkgDir)
+		log.TPrintf("- %s/__init__.py - found, plain install", pkgDir)
 		return false
 	}
 	if utility.FileExists(filepath.Join(projectDir, "src", pkgDir, "__init__.py")) {
-		log.TPrintf("- poetry --no-root: src/%s/__init__.py found, plain install", pkgDir)
+		log.TPrintf("- src/%s/__init__.py - found, plain install", pkgDir)
 		return false
 	}
 
-	log.TPrintf("- poetry --no-root: no installable package layout, using --no-root")
+	log.TPrintf("- installable package layout - not found, using --no-root")
 	return true
 }
 

--- a/scanners/python/detection.go
+++ b/scanners/python/detection.go
@@ -64,6 +64,11 @@ func collectPythonProjectDirs(searchDir string) ([]string, error) {
 func detectPackageManager(projectDir string) string {
 	log.TPrintf("Checking package manager")
 
+	if utility.FileExists(filepath.Join(projectDir, "uv.lock")) {
+		log.TPrintf("- uv.lock - found")
+		return "uv"
+	}
+
 	if utility.FileExists(filepath.Join(projectDir, "poetry.lock")) {
 		log.TPrintf("- poetry.lock - found")
 		return "poetry"

--- a/scanners/python/detection.go
+++ b/scanners/python/detection.go
@@ -201,6 +201,23 @@ func hasPytestInRequirementsFiles(projectDir string) bool {
 	return false
 }
 
+// detectDevRequirementsFile returns the first dev/test requirements file found in projectDir, or "".
+func detectDevRequirementsFile(projectDir string) string {
+	devFiles := []string{
+		"requirements-dev.txt",
+		"requirements-test.txt",
+		"requirements_dev.txt",
+		"requirements_test.txt",
+	}
+	for _, name := range devFiles {
+		if utility.FileExists(filepath.Join(projectDir, name)) {
+			log.TPrintf("- dev requirements: %s - found", name)
+			return name
+		}
+	}
+	return ""
+}
+
 // packageName extracts the package name from a requirements.txt line by stripping version specifiers.
 func packageName(line string) string {
 	i := strings.IndexAny(line, "=<>![ ;#\t")

--- a/scanners/python/detection.go
+++ b/scanners/python/detection.go
@@ -232,6 +232,108 @@ func packageName(line string) string {
 	return strings.TrimSpace(line[:i])
 }
 
+type pyprojectInfo struct {
+	poetryPackageModeFalse bool
+	poetryHasPackagesField bool
+	poetryName             string
+	projectName            string
+}
+
+func parsePyproject(content string) pyprojectInfo {
+	info := pyprojectInfo{}
+	section := ""
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			section = trimmed
+			continue
+		}
+		switch section {
+		case "[tool.poetry]":
+			if strings.HasPrefix(trimmed, "package-mode") {
+				if parts := strings.SplitN(trimmed, "=", 2); len(parts) == 2 && strings.TrimSpace(parts[1]) == "false" {
+					info.poetryPackageModeFalse = true
+				}
+			}
+			if strings.HasPrefix(trimmed, "packages") && strings.Contains(trimmed, "=") {
+				info.poetryHasPackagesField = true
+			}
+			if strings.HasPrefix(trimmed, "name") {
+				if v := pyprojectStringValue(trimmed); v != "" {
+					info.poetryName = v
+				}
+			}
+		case "[project]":
+			if strings.HasPrefix(trimmed, "name") {
+				if v := pyprojectStringValue(trimmed); v != "" {
+					info.projectName = v
+				}
+			}
+		}
+	}
+	return info
+}
+
+func pyprojectStringValue(line string) string {
+	parts := strings.SplitN(line, "=", 2)
+	if len(parts) < 2 {
+		return ""
+	}
+	return strings.Trim(strings.TrimSpace(parts[1]), `"'`)
+}
+
+// detectPoetryNeedsNoRoot decides whether `poetry install` should be invoked
+// with --no-root. Plain `poetry install` fails when poetry is in package mode
+// but the project doesn't ship an installable package, which is the common app
+// case (FastAPI/Django/Flask services). For library projects with a real
+// package layout we skip --no-root so the package is installed for tests that
+// rely on entry points or installed metadata.
+//
+// Heuristics in priority order:
+//  1. `package-mode = false` in [tool.poetry]                       -> no --no-root
+//  2. explicit `packages = ...` in [tool.poetry]                    -> no --no-root
+//  3. project name resolves to <dir>/__init__.py or src/<dir>/__init__.py -> no --no-root
+//  4. otherwise                                                     -> use --no-root
+func detectPoetryNeedsNoRoot(projectDir string) bool {
+	content, err := fileutil.ReadStringFromFile(filepath.Join(projectDir, "pyproject.toml"))
+	if err != nil {
+		log.TPrintf("- poetry --no-root: pyproject.toml not found, defaulting to --no-root")
+		return true
+	}
+
+	info := parsePyproject(content)
+	if info.poetryPackageModeFalse {
+		log.TPrintf("- poetry --no-root: package-mode = false set, plain install")
+		return false
+	}
+	if info.poetryHasPackagesField {
+		log.TPrintf("- poetry --no-root: explicit [tool.poetry] packages declared, plain install")
+		return false
+	}
+
+	name := info.poetryName
+	if name == "" {
+		name = info.projectName
+	}
+	if name == "" {
+		log.TPrintf("- poetry --no-root: no project name found, defaulting to --no-root")
+		return true
+	}
+
+	pkgDir := strings.ReplaceAll(name, "-", "_")
+	if utility.FileExists(filepath.Join(projectDir, pkgDir, "__init__.py")) {
+		log.TPrintf("- poetry --no-root: %s/__init__.py found, plain install", pkgDir)
+		return false
+	}
+	if utility.FileExists(filepath.Join(projectDir, "src", pkgDir, "__init__.py")) {
+		log.TPrintf("- poetry --no-root: src/%s/__init__.py found, plain install", pkgDir)
+		return false
+	}
+
+	log.TPrintf("- poetry --no-root: no installable package layout, using --no-root")
+	return true
+}
+
 func detectFramework(projectDir string) string {
 	log.TPrintf("Checking framework")
 

--- a/scanners/python/detection_test.go
+++ b/scanners/python/detection_test.go
@@ -1,0 +1,78 @@
+package python
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePyproject(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    pyprojectInfo
+	}{
+		{
+			name: "poetry name only",
+			content: `[tool.poetry]
+name = "my-app"
+version = "0.1.0"
+`,
+			want: pyprojectInfo{poetryName: "my-app"},
+		},
+		{
+			name: "package-mode false",
+			content: `[tool.poetry]
+name = "my-app"
+package-mode = false
+`,
+			want: pyprojectInfo{poetryName: "my-app", poetryPackageModeFalse: true},
+		},
+		{
+			name: "explicit packages declaration",
+			content: `[tool.poetry]
+name = "my-lib"
+packages = [{ include = "my_lib" }]
+`,
+			want: pyprojectInfo{poetryName: "my-lib", poetryHasPackagesField: true},
+		},
+		{
+			name: "PEP 621 project name only",
+			content: `[project]
+name = "modern-lib"
+`,
+			want: pyprojectInfo{projectName: "modern-lib"},
+		},
+		{
+			name: "both project and tool.poetry",
+			content: `[project]
+name = "modern-lib"
+
+[tool.poetry]
+name = "legacy-name"
+`,
+			want: pyprojectInfo{projectName: "modern-lib", poetryName: "legacy-name"},
+		},
+		{
+			name: "single quotes",
+			content: `[tool.poetry]
+name = 'my-app'
+`,
+			want: pyprojectInfo{poetryName: "my-app"},
+		},
+		{
+			name: "fields outside tool.poetry are ignored",
+			content: `[tool.poetry.dependencies]
+name = "this-is-a-dep-not-the-project"
+`,
+			want: pyprojectInfo{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parsePyproject(tt.content)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/scanners/python/detection_test.go
+++ b/scanners/python/detection_test.go
@@ -26,7 +26,7 @@ version = "0.1.0"
 name = "my-app"
 package-mode = false
 `,
-			want: pyprojectInfo{poetryName: "my-app", poetryPackageModeFalse: true},
+			want: pyprojectInfo{poetryName: "my-app", poetryPackageModeDisabled: true},
 		},
 		{
 			name: "explicit packages declaration",

--- a/scanners/python/python.go
+++ b/scanners/python/python.go
@@ -29,7 +29,6 @@ type project struct {
 	projectRelDir  string
 	packageManager string
 	hasPytest      bool
-	framework      string
 	pythonVersion  string
 }
 
@@ -95,14 +94,13 @@ func (s *Scanner) Options() (models.OptionNode, models.Warnings, models.Icons, e
 		pkgMgr := detectPackageManager(absDir)
 		pythonVersion := detectPythonVersion(absDir)
 		hasPytest := detectTestRunner(absDir)
-		framework := detectFramework(absDir)
+		detectFramework(absDir)
 
 		s.projects = append(s.projects, project{
 			projectRelDir:  relDir,
 			packageManager: pkgMgr,
 			pythonVersion:  pythonVersion,
 			hasPytest:      hasPytest,
-			framework:      framework,
 		})
 	}
 

--- a/scanners/python/python.go
+++ b/scanners/python/python.go
@@ -29,7 +29,6 @@ type project struct {
 	projectRelDir  string
 	packageManager string
 	hasPytest      bool
-	hasUnittest    bool
 	framework      string
 	pythonVersion  string
 }
@@ -95,7 +94,7 @@ func (s *Scanner) Options() (models.OptionNode, models.Warnings, models.Icons, e
 
 		pkgMgr := detectPackageManager(absDir)
 		pythonVersion := detectPythonVersion(absDir)
-		hasPytest, hasUnittest := detectTestRunner(absDir)
+		hasPytest := detectTestRunner(absDir)
 		framework := detectFramework(absDir)
 
 		s.projects = append(s.projects, project{
@@ -103,7 +102,6 @@ func (s *Scanner) Options() (models.OptionNode, models.Warnings, models.Icons, e
 			packageManager: pkgMgr,
 			pythonVersion:  pythonVersion,
 			hasPytest:      hasPytest,
-			hasUnittest:    hasUnittest,
 			framework:      framework,
 		})
 	}

--- a/scanners/python/python.go
+++ b/scanners/python/python.go
@@ -1,0 +1,151 @@
+package python
+
+import (
+	"path/filepath"
+
+	"github.com/bitrise-io/bitrise-init/models"
+	"github.com/bitrise-io/bitrise-init/utility"
+	"github.com/bitrise-io/go-utils/log"
+)
+
+const (
+	scannerName = "python"
+
+	projectDirInputTitle   = "Python Project Directory"
+	projectDirInputSummary = "The directory containing the Python project files (requirements.txt, pyproject.toml, etc.)"
+	projectDirInputEnvKey  = "PYTHON_PROJECT_DIR"
+
+	packageManagerInputTitle   = "Package Manager"
+	packageManagerInputSummary = "The package manager used in the project"
+
+	pythonVersionInputTitle   = "Python version"
+	pythonVersionInputSummary = "The Python version to be used for the project. Use exact (3.12.0) or partial (3.12:latest, 3:installed) versions."
+	pythonVersionEnvKey       = "PYTHON_VERSION"
+)
+
+var packageManagers = []string{"pip", "poetry"}
+
+type project struct {
+	projectRelDir  string
+	packageManager string
+	hasPytest      bool
+	hasUnittest    bool
+	framework      string
+	pythonVersion  string
+}
+
+// Scanner implements ScannerInterface for Python projects.
+type Scanner struct {
+	searchDir   string
+	projectDirs []string // relative paths, populated by DetectPlatform
+	projects    []project // populated by Options()
+}
+
+// NewScanner creates a new Scanner instance.
+func NewScanner() *Scanner {
+	return &Scanner{}
+}
+
+// Name returns the scanner name.
+func (s *Scanner) Name() string {
+	return scannerName
+}
+
+// DetectPlatform checks whether searchDir contains a Python project.
+// It only confirms the platform is present; detailed analysis happens in Options().
+func (s *Scanner) DetectPlatform(searchDir string) (bool, error) {
+	s.searchDir = searchDir
+
+	dirs, err := collectPythonProjectDirs(searchDir)
+	if err != nil {
+		log.TWarnf("%s", err)
+		log.TPrintf("Platform not detected")
+		return false, nil
+	}
+
+	for _, dir := range dirs {
+		relDir, err := utility.RelPath(searchDir, dir)
+		if err != nil {
+			log.TWarnf("failed to get relative project dir path: %s", err)
+			continue
+		}
+		log.TPrintf("Python project found: %s", relDir)
+		s.projectDirs = append(s.projectDirs, relDir)
+	}
+
+	if len(s.projectDirs) == 0 {
+		log.TPrintf("Platform not detected")
+		return false, nil
+	}
+
+	log.TSuccessf("Platform detected")
+	return true, nil
+}
+
+// ExcludedScannerNames returns scanners to skip when this scanner detects.
+func (s *Scanner) ExcludedScannerNames() []string {
+	return []string{}
+}
+
+// Options performs detailed analysis for each detected project dir and builds the option tree.
+func (s *Scanner) Options() (models.OptionNode, models.Warnings, models.Icons, error) {
+	for _, relDir := range s.projectDirs {
+		absDir := filepath.Join(s.searchDir, relDir)
+		log.TPrintf("Checking: %s", relDir)
+
+		pkgMgr := detectPackageManager(absDir)
+		pythonVersion := detectPythonVersion(absDir)
+		hasPytest, hasUnittest := detectTestRunner(absDir)
+		framework := detectFramework(absDir)
+
+		s.projects = append(s.projects, project{
+			projectRelDir:  relDir,
+			packageManager: pkgMgr,
+			pythonVersion:  pythonVersion,
+			hasPytest:      hasPytest,
+			hasUnittest:    hasUnittest,
+			framework:      framework,
+		})
+	}
+
+	return generateOptions(s.projects)
+}
+
+// Configs generates the pre-made bitrise.yml templates for each detected project.
+func (s *Scanner) Configs(sshKeyActivation models.SSHKeyActivation) (models.BitriseConfigMap, error) {
+	return generateConfigs(s.projects, sshKeyActivation)
+}
+
+// DefaultOptions returns the option tree for the manual configuration flow.
+func (s *Scanner) DefaultOptions() models.OptionNode {
+	projectDirOption := models.NewOption(projectDirInputTitle, projectDirInputSummary, projectDirInputEnvKey, models.TypeUserInput)
+	versionOption := models.NewOption(pythonVersionInputTitle, pythonVersionInputSummary, pythonVersionEnvKey, models.TypeUserInput)
+	pkgMgrOption := models.NewOption(packageManagerInputTitle, packageManagerInputSummary, "", models.TypeSelector)
+
+	projectDirOption.AddOption(models.UserInputOptionDefaultValue, versionOption)
+	versionOption.AddOption(models.UserInputOptionDefaultValue, pkgMgrOption)
+
+	for _, pm := range packageManagers {
+		descriptor := createDefaultConfigDescriptor(pm)
+		configOption := models.NewConfigOption(configName(descriptor), nil)
+		pkgMgrOption.AddConfig(pm, configOption)
+	}
+
+	return *projectDirOption
+}
+
+// DefaultConfigs generates the static bitrise.yml templates for the manual configuration flow.
+func (s *Scanner) DefaultConfigs() (models.BitriseConfigMap, error) {
+	configs := models.BitriseConfigMap{}
+
+	for _, pm := range packageManagers {
+		descriptor := createDefaultConfigDescriptor(pm)
+		config, err := generateConfigBasedOn(descriptor, models.SSHKeyActivationConditional)
+		if err != nil {
+			return nil, err
+		}
+		configs[configName(descriptor)] = config
+	}
+
+	return configs, nil
+}

--- a/scanners/python/python.go
+++ b/scanners/python/python.go
@@ -26,10 +26,11 @@ const (
 var packageManagers = []string{"pip", "poetry"}
 
 type project struct {
-	projectRelDir  string
-	packageManager string
-	hasPytest      bool
-	pythonVersion  string
+	projectRelDir       string
+	packageManager      string
+	hasPytest           bool
+	pythonVersion       string
+	devRequirementsFile string
 }
 
 // Scanner implements ScannerInterface for Python projects.
@@ -94,13 +95,15 @@ func (s *Scanner) Options() (models.OptionNode, models.Warnings, models.Icons, e
 		pkgMgr := detectPackageManager(absDir)
 		pythonVersion := detectPythonVersion(absDir)
 		hasPytest := detectTestRunner(absDir)
+		devReqFile := detectDevRequirementsFile(absDir)
 		detectFramework(absDir)
 
 		s.projects = append(s.projects, project{
-			projectRelDir:  relDir,
-			packageManager: pkgMgr,
-			pythonVersion:  pythonVersion,
-			hasPytest:      hasPytest,
+			projectRelDir:       relDir,
+			packageManager:      pkgMgr,
+			pythonVersion:       pythonVersion,
+			hasPytest:           hasPytest,
+			devRequirementsFile: devReqFile,
 		})
 	}
 

--- a/scanners/python/python.go
+++ b/scanners/python/python.go
@@ -23,7 +23,7 @@ const (
 	pythonVersionEnvKey       = "PYTHON_VERSION"
 )
 
-var packageManagers = []string{"pip", "poetry"}
+var packageManagers = []string{"pip", "poetry", "uv"}
 
 type project struct {
 	projectRelDir       string

--- a/scanners/python/python.go
+++ b/scanners/python/python.go
@@ -31,12 +31,13 @@ type project struct {
 	hasPytest           bool
 	pythonVersion       string
 	devRequirementsFile string
+	poetryNeedsNoRoot   bool
 }
 
 // Scanner implements ScannerInterface for Python projects.
 type Scanner struct {
 	searchDir   string
-	projectDirs []string // relative paths, populated by DetectPlatform
+	projectDirs []string  // relative paths, populated by DetectPlatform
 	projects    []project // populated by Options()
 }
 
@@ -98,12 +99,18 @@ func (s *Scanner) Options() (models.OptionNode, models.Warnings, models.Icons, e
 		devReqFile := detectDevRequirementsFile(absDir)
 		detectFramework(absDir)
 
+		needsNoRoot := false
+		if pkgMgr == "poetry" {
+			needsNoRoot = detectPoetryNeedsNoRoot(absDir)
+		}
+
 		s.projects = append(s.projects, project{
 			projectRelDir:       relDir,
 			packageManager:      pkgMgr,
 			pythonVersion:       pythonVersion,
 			hasPytest:           hasPytest,
 			devRequirementsFile: devReqFile,
+			poetryNeedsNoRoot:   needsNoRoot,
 		})
 	}
 

--- a/scanners/scanners.go
+++ b/scanners/scanners.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bitrise-io/bitrise-init/scanners/kmp"
 	"github.com/bitrise-io/bitrise-init/scanners/macos"
 	"github.com/bitrise-io/bitrise-init/scanners/nodejs"
+	"github.com/bitrise-io/bitrise-init/scanners/python"
 	"github.com/bitrise-io/bitrise-init/scanners/reactnative"
 	"github.com/bitrise-io/bitrise-init/scanners/ruby"
 	"github.com/bitrise-io/bitrise-init/steps"
@@ -85,6 +86,7 @@ func ProjectScanners() []ScannerInterface {
 		nodejs.NewScanner(),
 		java.NewScanner(),
 		ruby.NewScanner(),
+		python.NewScanner(),
 	}
 }
 

--- a/vendor/github.com/bitrise-io/go-flutter/flutterproject/internal/sdk/fvm_config.go
+++ b/vendor/github.com/bitrise-io/go-flutter/flutterproject/internal/sdk/fvm_config.go
@@ -10,6 +10,7 @@ import (
 )
 
 const fvmConfigRelPath = ".fvm/fvm_config.json"
+const fvmrcRelPath = ".fvmrc"
 
 type FVMVersionReader struct {
 	fileOpener FileOpener
@@ -22,8 +23,30 @@ func NewFVMVersionReader(fileOpener FileOpener) FVMVersionReader {
 }
 
 func (r FVMVersionReader) ReadSDKVersion(projectRootDir string) (*semver.Version, string, error) {
+	// Try FVM 2.x format first (.fvm/fvm_config.json)
 	fvmConfigPth := filepath.Join(projectRootDir, fvmConfigRelPath)
 	f, err := r.fileOpener.OpenReaderIfExists(fvmConfigPth)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if f != nil {
+		versionStr, channel, err := parseFVMFlutterVersion(f)
+		if err != nil {
+			return nil, "", err
+		}
+		if versionStr != "" {
+			version, err := semver.NewVersion(versionStr)
+			if err != nil {
+				return nil, "", err
+			}
+			return version, channel, nil
+		}
+	}
+
+	// Try FVM 3.x format (.fvmrc)
+	fvmrcPth := filepath.Join(projectRootDir, fvmrcRelPath)
+	f, err = r.fileOpener.OpenReaderIfExists(fvmrcPth)
 	if err != nil {
 		return nil, "", err
 	}
@@ -32,7 +55,7 @@ func (r FVMVersionReader) ReadSDKVersion(projectRootDir string) (*semver.Version
 		return nil, "", nil
 	}
 
-	versionStr, channel, err := parseFVMFlutterVersion(f)
+	versionStr, channel, err := parseFVMRCFlutterVersion(f)
 	if err != nil {
 		return nil, "", err
 	}
@@ -62,6 +85,28 @@ func parseFVMFlutterVersion(fvmConfigReader io.Reader) (string, string, error) {
 	version := config.FlutterSdkVersion
 	channel := ""
 	s := strings.Split(config.FlutterSdkVersion, "@")
+	if len(s) > 1 {
+		version = s[0]
+		channel = strings.Join(s[1:], "@")
+	}
+
+	return version, channel, nil
+}
+
+func parseFVMRCFlutterVersion(fvmrcReader io.Reader) (string, string, error) {
+	type fvmrc struct {
+		Flutter string `json:"flutter"`
+	}
+
+	var config fvmrc
+	d := json.NewDecoder(fvmrcReader)
+	if err := d.Decode(&config); err != nil {
+		return "", "", err
+	}
+
+	version := config.Flutter
+	channel := ""
+	s := strings.Split(config.Flutter, "@")
 	if len(s) > 1 {
 		version = s[0]
 		channel = strings.Join(s[1:], "@")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -16,7 +16,7 @@ github.com/bitrise-io/bitrise/v2/version
 # github.com/bitrise-io/envman/v2 v2.5.6
 ## explicit; go 1.25.3
 github.com/bitrise-io/envman/v2/models
-# github.com/bitrise-io/go-flutter v0.1.2-0.20260413123617-d1289effff65
+# github.com/bitrise-io/go-flutter v0.2.1-0.20260428141131-b93699c0adfe
 ## explicit; go 1.20
 github.com/bitrise-io/go-flutter/flutterproject
 github.com/bitrise-io/go-flutter/flutterproject/internal/sdk

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -16,7 +16,7 @@ github.com/bitrise-io/bitrise/v2/version
 # github.com/bitrise-io/envman/v2 v2.5.6
 ## explicit; go 1.25.3
 github.com/bitrise-io/envman/v2/models
-# github.com/bitrise-io/go-flutter v0.2.1-0.20260428141131-b93699c0adfe
+# github.com/bitrise-io/go-flutter v0.3.0
 ## explicit; go 1.20
 github.com/bitrise-io/go-flutter/flutterproject
 github.com/bitrise-io/go-flutter/flutterproject/internal/sdk


### PR DESCRIPTION
### Version
Requires a *MINOR* [version update](https://semver.org/)

### Context

Python projects (FastAPI, Django, Flask, plain pytest apps) had no automatic CI config generation in the "Add new app" flow. This PR adds a Python scanner that covers both the automatic scan path and the manual configuration path.

### Changes

- Add `scanners/python` implementing `ScannerInterface`.
- Detection (positive if any marker file is found, excluding `.git`, `node_modules`, `.venv`, `venv`, `__pycache__`):
  - Marker files: `requirements.txt`, `pyproject.toml`, `Pipfile`, `setup.py`. Each containing directory is treated as a separate project (monorepo support).
  - Package manager priority: `uv.lock`, then `poetry.lock`, then `requirements.txt`. If none of these are present, the user picks during setup and a config is generated for every option.
  - Python version: `.python-version`, then `.tool-versions`, then `pyproject.toml` `requires-python` (operators stripped). Set as `tools: { python: <version> }` when found.
  - Pytest: detected via `pytest.ini`, `conftest.py`, `[tool.pytest…]` in `pyproject.toml`, or a `pytest` entry in any of the supported requirements files.
  - Dev requirements: first match of `requirements-dev.txt`, `requirements-test.txt`, `requirements_dev.txt`, `requirements_test.txt`. Installed alongside `requirements.txt` in the pip flow.
  - Poetry `--no-root` requirement: detected from `pyproject.toml`. Plain `poetry install` is emitted when `package-mode = false` is set, when `[tool.poetry] packages = ...` is declared, or when a default package layout exists at `<name>/__init__.py` or `src/<name>/__init__.py`. Otherwise `poetry install --no-root` is used.
  - Framework (FastAPI, Django, Flask) is logged for scan visibility only; it does not currently affect the generated workflow.
- Generated `run_tests` workflow per package manager:
  - pip: `pip install --upgrade pip; pip install -r requirements.txt` (plus the dev requirements file when detected), test with `pytest`.
  - poetry: `pip install poetry; poetry install [--no-root]`, test with `poetry run pytest`. Poetry is bootstrapped via pip because it is not pre-installed on the Bitrise stacks.
  - uv: `pip install uv; uv sync`, test with `uv run pytest`. Same bootstrap reason as Poetry.
  - Each manager has its own cache key (lockfile hash) and cache paths: `~/.cache/pip`, `~/.cache/pypoetry`, `~/.cache/uv`.
- Manual config prompts for `PYTHON_PROJECT_DIR`, `PYTHON_VERSION`, and **Package Manager** (pip / poetry / uv); a `bitrise tools install python $PYTHON_VERSION` script step replaces the declarative `tools` block. The manual Poetry config defaults to `--no-root` because per-project detection is not possible at generation time.
- Register the scanner in `scanners.ProjectScanners()` after `ruby` (no `ExcludedScannerNames`).
- Tests:
  - Unit tests for `parsePyproject` in `scanners/python/detection_test.go`.
  - Integration tests in `_tests/integration/python_test.go` against `bitrise-io/python-samples` (pip, poetry, uv fixtures).
  - Manual config tests extended for the Python defaults.

### Investigation details

- Initial implementation supported only pip; poetry and uv were added incrementally as `packageManagers` is a single slice that drives both scan and default config branches.
- Poetry and uv are not pre-installed on the Bitrise stacks, so the install scripts bootstrap them with `pip install <tool>` before running their commands. This avoids requiring stack changes for the feature to ship.
- The Poetry `--no-root` decision is the only meaningful per-project variant beyond the manager itself. Detection mirrors Poetry's own package resolution order (`package-mode = false`, explicit `packages`, default layout), so the generated config matches what `poetry install` would actually do for that project.

### Decisions

- `DetectPlatform` only collects candidate project dirs; richer parsing (package manager, version, test runner, dev requirements, `--no-root`) runs in `Options()` per the per-scanner execution flow.
- Python does not exclude any other scanner (no overlap with mobile / cross-platform scanners).
- Dev requirements are installed only in the pip flow; poetry and uv handle dev groups through their own lockfiles, so no extra step is needed there.
- The manual Poetry config defaults to `--no-root` because (a) detection is not possible at generation time, (b) `--no-root` succeeds in both app and library cases (pytest discovers in-tree packages without installation), (c) users who need root install can edit the workflow.
